### PR TITLE
Return code object only for text layers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -154,7 +154,7 @@ function layer(context, selectedLayer) {
     const code = labelTemplate(label);
     return xamlCode(code);
   }
-  return '';
+  return null;
 }
 
 const extension = {


### PR DESCRIPTION
The Mac app displays a blank code section when extension functions return an empty string. If the extension is not supposed to generate code for a certain case, it's better to return `null` (or nothing).

![image](https://user-images.githubusercontent.com/721036/38735775-808382be-3f32-11e8-9682-3c8e2febdbcf.png)
