### PR TITLE
Fixed typo in textStyles template

### DIFF
--- a/src/templates/textStyles.mustache
+++ b/src/templates/textStyles.mustache
@@ -15,7 +15,7 @@
     {{/fontAttribute}}
     {{#textColor}}
     <Setter Property="TextColor"
-            Value="{{TextColor}}" />
+            Value="{{textColor}}" />
     {{/textColor}}
     {{#horizontalTextAlignment}}
     <Setter Property="HorizontalTextAlignment"


### PR DESCRIPTION
"TextColor" property in text styles is not set 

![zeplinxamarinformsmissingtextcolor](https://user-images.githubusercontent.com/29101012/48628921-a23d9800-e9b8-11e8-9889-34a06bf34c4c.png)
